### PR TITLE
fix de refresh al hacer un movimiento

### DIFF
--- a/client/js/income.js
+++ b/client/js/income.js
@@ -63,6 +63,8 @@ window.onRemove = async function () {
     await movementService.update(state.movement);
     state.movement = {};
     render('movement-form.html', state, refs.form);
+    state.movements = await getIncomes();
+    renderIncomes(state);
 };
 
 /**
@@ -81,6 +83,8 @@ window.onSave = async function (e) {
 
     state.movement = {};
     render('movement-form.html', state, refs.form);
+    state.movements = await getIncomes();
+    renderIncomes(state);
 };
 
 init();


### PR DESCRIPTION
**Qué se hizo?**
Se agregó renderizar los últimos movimientos al momento de agregar o editar un movimiento.

**Por qué se hizo**
Porque había un bug que cuando se agregaba o editaba un movimiento, éste no estaba apareciendo reflejado en la lista.